### PR TITLE
Typo in link to CXML documentaiton

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ you can do it in one pass:
                                          (get-output-stream-string text))))))
       ...)
 
-[CXML]: http://common-lisp.net/project/fxml/
+[CXML]: http://common-lisp.net/project/cxml/
 [defusedxml]: https://pypi.python.org/pypi/defusedxml
 [billion laughs]: https://en.wikipedia.org/wiki/Billion_laughs
 [sax]: https://common-lisp.net/project/cxml/saxoverview/


### PR DESCRIPTION
Introduced in the when gloablly renaming cxml to fxml in 120aff0790b8ddf675ec8e7c19bf4f034dd4b7f7